### PR TITLE
Enforce SQLite foreign keys at init and verify at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 2. Set `GEMINI_API_KEY` in `.env.local`
 3. Start the app: `npm run dev`
 
+## SQLite relational integrity in local dev
+
+- SecurePulse enables `PRAGMA foreign_keys = ON` during SQLite initialization.
+- App startup asserts this setting remains enabled and logs: `[startup] SQLite foreign key enforcement confirmed active.`
+- If SQLite cannot enforce foreign keys, startup fails fast to avoid accepting inconsistent relational data.
+
 ## Secret handling policy
 
 - `GEMINI_API_KEY` is **server-only** and must never be injected into Vite client bundles.

--- a/server.ts
+++ b/server.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 import { MissingGeminiKeyError, generateBriefCard } from "./server/lib/ai.ts";
 import { BriefCard, IntelItem } from "./server/lib/models.ts";
 import { parseGenerateBriefRequest, parseIntelItem, ParseFailureError } from "./server/lib/parse.ts";
+import db from "./src/lib/db.ts";
 
 dotenv.config();
 
@@ -44,6 +45,12 @@ function formatLegacyBriefResponse(brief: BriefCard): BriefCard & { summaryBulle
 async function startServer() {
   const app = express();
   const PORT = 3000;
+
+  const foreignKeyStatus = db.pragma("foreign_keys", { simple: true });
+  if (foreignKeyStatus !== 1) {
+    throw new Error("SQLite foreign key enforcement is not active at startup.");
+  }
+  console.log("[startup] SQLite foreign key enforcement confirmed active.");
 
   app.use(express.json());
 

--- a/server/lib/__tests__/db-foreign-keys.test.ts
+++ b/server/lib/__tests__/db-foreign-keys.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createDatabase } from "../../../src/lib/db.ts";
+
+test("SQLite rejects FK violations for brief_cards.brief_id", () => {
+  const db = createDatabase(":memory:", { logger: { log: () => {} } });
+
+  assert.throws(
+    () => {
+      db.prepare(
+        `INSERT INTO brief_cards (id, brief_id, type, title, summary, why_it_matters, suggested_action, confidence)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "card-1",
+        "missing-brief",
+        "THREAT",
+        "Test title",
+        JSON.stringify(["item"]),
+        "Test why",
+        "Test action",
+        "HIGH",
+      );
+    },
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /FOREIGN KEY constraint failed/);
+      return true;
+    },
+  );
+
+  db.close();
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,6 +2,61 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 
+export function initializeSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS intel_items (
+      id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      external_id TEXT UNIQUE NOT NULL,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      url TEXT,
+      published_at DATETIME NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS daily_briefs (
+      id TEXT PRIMARY KEY,
+      date TEXT UNIQUE NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS brief_cards (
+      id TEXT PRIMARY KEY,
+      brief_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL, -- Stored as JSON array
+      why_it_matters TEXT NOT NULL,
+      suggested_action TEXT,
+      confidence TEXT NOT NULL,
+      FOREIGN KEY(brief_id) REFERENCES daily_briefs(id)
+    );
+  `);
+}
+
+type CreateDatabaseOptions = {
+  logger?: Pick<Console, 'log'>;
+};
+
+export function createDatabase(dbPath: string, options: CreateDatabaseOptions = {}): Database.Database {
+  const { logger = console } = options;
+  const db = new Database(dbPath);
+
+  db.pragma('foreign_keys = ON');
+  const foreignKeyStatus = db.pragma('foreign_keys', { simple: true });
+
+  if (foreignKeyStatus !== 1) {
+    throw new Error('SQLite foreign key enforcement could not be enabled.');
+  }
+
+  logger.log('[db] SQLite foreign key enforcement enabled.');
+
+  initializeSchema(db);
+
+  return db;
+}
+
 // Ensure data directory exists
 const dataDir = path.join(process.cwd(), 'data');
 if (!fs.existsSync(dataDir)) {
@@ -9,38 +64,6 @@ if (!fs.existsSync(dataDir)) {
 }
 
 const dbPath = path.join(dataDir, 'securepulse.db');
-const db = new Database(dbPath);
-
-// Initialize schema
-db.exec(`
-  CREATE TABLE IF NOT EXISTS intel_items (
-    id TEXT PRIMARY KEY,
-    source TEXT NOT NULL,
-    external_id TEXT UNIQUE NOT NULL,
-    title TEXT NOT NULL,
-    content TEXT NOT NULL,
-    url TEXT,
-    published_at DATETIME NOT NULL,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-  );
-
-  CREATE TABLE IF NOT EXISTS daily_briefs (
-    id TEXT PRIMARY KEY,
-    date TEXT UNIQUE NOT NULL,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-  );
-
-  CREATE TABLE IF NOT EXISTS brief_cards (
-    id TEXT PRIMARY KEY,
-    brief_id TEXT NOT NULL,
-    type TEXT NOT NULL,
-    title TEXT NOT NULL,
-    summary TEXT NOT NULL, -- Stored as JSON array
-    why_it_matters TEXT NOT NULL,
-    suggested_action TEXT,
-    confidence TEXT NOT NULL,
-    FOREIGN KEY(brief_id) REFERENCES daily_briefs(id)
-  );
-`);
+const db = createDatabase(dbPath);
 
 export default db;


### PR DESCRIPTION
### Motivation

- Ensure relational integrity for the local SQLite database so child records cannot reference missing parents. 
- Fail fast and make enforcement observable during development to avoid accepting inconsistent data.

### Description

- Refactored DB init in `src/lib/db.ts` into `createDatabase(...)` and `initializeSchema(...)`, and enabled `PRAGMA foreign_keys = ON` immediately after connecting. 
- `createDatabase` asserts the pragma is active and logs `[db] SQLite foreign key enforcement enabled.` before creating schema, and the default `db` export now uses this initializer. 
- Added a startup-time check in `server.ts` that re-reads `PRAGMA foreign_keys` and logs `[startup] SQLite foreign key enforcement confirmed active.` and fails startup if enforcement is not active. 
- Added a unit test `server/lib/__tests__/db-foreign-keys.test.ts` that proves inserting a `brief_cards` row referencing a missing `daily_briefs` parent raises a `FOREIGN KEY constraint failed` error, and documented behavior in `README.md`.

### Testing

- Ran `npm test`, which executed the new FK test plus existing tests and all tests passed (TAP output showed 5/5 tests passing). 
- Ran `npm run lint` (`tsc --noEmit`) and type checks completed successfully. 
- Started the dev server (`npm run dev`) briefly and verified both `[db] SQLite foreign key enforcement enabled.` and `[startup] SQLite foreign key enforcement confirmed active.` were emitted in the startup logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dbceed888323b3ebfb1aada873f2)