### PR TITLE
DB-backed personalization, scoring, and CRUD APIs for subscriptions/preferences

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,25 +1,19 @@
-import express from "express";
 import { createServer as createViteServer } from "vite";
 import dotenv from "dotenv";
 import { createIngestionService } from "./server/lib/ingestion/index";
 import prisma from "./server/lib/prisma";
+import express from "express";
+import { createApp } from "./server/app";
 
 dotenv.config();
 
 async function startServer() {
-  const app = express();
+  const app = createApp(prisma as any);
   const PORT = 3000;
-
-  app.use(express.json());
-
-  // API routes go here
-  app.get("/api/health", (req, res) => {
-    res.json({ status: "ok", app: "SecurePulse MVP" });
-  });
 
   const ingestionService = createIngestionService();
 
-  app.post("/api/ingest/run", async (req, res) => {
+  app.post("/api/ingest/run", async (_req, res) => {
     try {
       await ingestionService.ingestAll();
       res.json({ status: "ok" });
@@ -33,13 +27,11 @@ async function startServer() {
     res.json({ replayed });
   });
 
-  app.get("/api/ingest/dlq", async (req, res) => {
+  app.get("/api/ingest/dlq", async (_req, res) => {
     const rows = await (prisma as any).deadLetterItem.findMany({ where: { replayedAt: null }, orderBy: { createdAt: "asc" } });
     res.json(rows);
   });
 
-
-  // Vite middleware for development
   if (process.env.NODE_ENV !== "production") {
     const vite = await createViteServer({
       server: { middlewareMode: true },
@@ -47,7 +39,6 @@ async function startServer() {
     });
     app.use(vite.middlewares);
   } else {
-    // In production, serve the built static files
     app.use(express.static("dist"));
   }
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,232 @@
+import express from "express";
+import type { PrismaClient } from "@prisma/client";
+import { scoreIntelForUser, type UserContext } from "./lib/personalization";
+import { INTEL_SEVERITIES, type IntelSeverity } from "./lib/severity";
+
+const severityOrder: Record<IntelSeverity, number> = {
+  LOW: 0,
+  MEDIUM: 1,
+  HIGH: 2,
+  CRITICAL: 3,
+};
+
+type DbClient = Pick<
+  PrismaClient,
+  "subscription" | "userPreference" | "intelItem"
+>;
+
+const isNonEmptyString = (value: unknown): value is string => typeof value === "string" && value.trim().length > 0;
+const isBoolean = (value: unknown): value is boolean => typeof value === "boolean";
+const isSeverity = (value: unknown): value is IntelSeverity =>
+  typeof value === "string" && (INTEL_SEVERITIES as readonly string[]).includes(value);
+
+function parseSubscriptionPayload(payload: unknown, partial = false) {
+  if (!payload || typeof payload !== "object") return { error: "payload must be an object" };
+  const body = payload as Record<string, unknown>;
+
+  const requiredFields = ["feedSourceId", "subscriberKey", "channel", "endpoint"];
+  if (!partial) {
+    for (const field of requiredFields) {
+      if (!isNonEmptyString(body[field])) return { error: `invalid ${field}` };
+    }
+  }
+
+  if (body.feedSourceId !== undefined && !isNonEmptyString(body.feedSourceId)) return { error: "invalid feedSourceId" };
+  if (body.subscriberKey !== undefined && !isNonEmptyString(body.subscriberKey)) return { error: "invalid subscriberKey" };
+  if (body.channel !== undefined && !isNonEmptyString(body.channel)) return { error: "invalid channel" };
+  if (body.endpoint !== undefined && !isNonEmptyString(body.endpoint)) return { error: "invalid endpoint" };
+  if (body.isActive !== undefined && !isBoolean(body.isActive)) return { error: "invalid isActive" };
+
+  return {
+    value: {
+      feedSourceId: body.feedSourceId,
+      subscriberKey: body.subscriberKey,
+      channel: body.channel,
+      endpoint: body.endpoint,
+      isActive: body.isActive,
+    },
+  };
+}
+
+function parsePreferencePayload(payload: unknown, partial = false) {
+  if (!payload || typeof payload !== "object") return { error: "payload must be an object" };
+  const body = payload as Record<string, unknown>;
+
+  if (!partial && !isNonEmptyString(body.subscriptionId)) return { error: "invalid subscriptionId" };
+  if (body.subscriptionId !== undefined && !isNonEmptyString(body.subscriptionId)) return { error: "invalid subscriptionId" };
+  if (body.timezone !== undefined && !isNonEmptyString(body.timezone)) return { error: "invalid timezone" };
+  if (
+    body.digestHourUtc !== undefined &&
+    (typeof body.digestHourUtc !== "number" || !Number.isInteger(body.digestHourUtc) || body.digestHourUtc < 0 || body.digestHourUtc > 23)
+  ) {
+    return { error: "invalid digestHourUtc" };
+  }
+  if (body.minimumSeverity !== undefined && !isSeverity(body.minimumSeverity)) return { error: "invalid minimumSeverity" };
+  if (body.includeRecommendations !== undefined && !isBoolean(body.includeRecommendations)) {
+    return { error: "invalid includeRecommendations" };
+  }
+
+  return {
+    value: {
+      subscriptionId: body.subscriptionId,
+      timezone: body.timezone,
+      digestHourUtc: body.digestHourUtc,
+      minimumSeverity: body.minimumSeverity,
+      includeRecommendations: body.includeRecommendations,
+    },
+  };
+}
+
+async function loadUserContext(db: DbClient, subscriberKey: string): Promise<UserContext> {
+  const activeSubscriptions = await db.subscription.findMany({
+    where: { subscriberKey, isActive: true },
+    include: {
+      feedSource: true,
+      userPreference: true,
+    },
+  });
+
+  if (activeSubscriptions.length === 0) {
+    return {
+      subscribedSourceSlugs: [],
+      minimumSeverity: "MEDIUM",
+      includeRecommendations: true,
+    };
+  }
+
+  let minimumSeverity: IntelSeverity = "MEDIUM";
+  let includeRecommendations = true;
+
+  for (const sub of activeSubscriptions) {
+    if (sub.userPreference) {
+      if (severityOrder[sub.userPreference.minimumSeverity] > severityOrder[minimumSeverity]) {
+        minimumSeverity = sub.userPreference.minimumSeverity;
+      }
+      includeRecommendations = includeRecommendations && sub.userPreference.includeRecommendations;
+    }
+  }
+
+  return {
+    subscribedSourceSlugs: [...new Set(activeSubscriptions.map((sub: any) => String(sub.feedSource.slug)))] as string[],
+    minimumSeverity,
+    includeRecommendations,
+  };
+}
+
+export function createApp(db: DbClient) {
+  const app = express();
+  app.use(express.json());
+
+  app.get("/api/health", (_req, res) => {
+    res.json({ status: "ok", app: "SecurePulse MVP" });
+  });
+
+  app.get("/api/users/:subscriberKey/context", async (req, res) => {
+    if (!isNonEmptyString(req.params.subscriberKey)) {
+      return res.status(400).json({ error: "invalid subscriberKey" });
+    }
+    const context = await loadUserContext(db, req.params.subscriberKey);
+    return res.json(context);
+  });
+
+  app.get("/api/users/:subscriberKey/personalized-intel", async (req, res) => {
+    if (!isNonEmptyString(req.params.subscriberKey)) {
+      return res.status(400).json({ error: "invalid subscriberKey" });
+    }
+
+    const context = await loadUserContext(db, req.params.subscriberKey);
+    const rows = await db.intelItem.findMany({
+      include: {
+        feedSource: true,
+        vulnerabilities: true,
+      },
+      orderBy: { publishedAt: "desc" },
+      take: 50,
+    });
+
+    const scored = rows
+      .map((row) => ({
+        id: row.id,
+        title: row.title,
+        severity: row.severity,
+        feedSourceSlug: row.feedSource.slug,
+        publishedAt: row.publishedAt,
+        score: scoreIntelForUser(
+          {
+            id: row.id,
+            title: row.title,
+            severity: row.severity,
+            feedSourceSlug: row.feedSource.slug,
+            vulnerabilities: row.vulnerabilities,
+          },
+          context,
+        ),
+      }))
+      .sort((a, b) => b.score - a.score || b.publishedAt.getTime() - a.publishedAt.getTime());
+
+    return res.json({ context, items: scored });
+  });
+
+  app.get("/api/subscriptions", async (req, res) => {
+    const subscriberKey = req.query.subscriberKey;
+    if (!isNonEmptyString(subscriberKey)) return res.status(400).json({ error: "invalid subscriberKey query" });
+
+    const rows = await db.subscription.findMany({ where: { subscriberKey }, include: { userPreference: true, feedSource: true } });
+    return res.json(rows);
+  });
+
+  app.post("/api/subscriptions", async (req, res) => {
+    const parsed = parseSubscriptionPayload(req.body, false);
+    if (parsed.error) return res.status(400).json({ error: parsed.error });
+
+    const created = await db.subscription.create({ data: parsed.value as any });
+    return res.status(201).json(created);
+  });
+
+  app.patch("/api/subscriptions/:id", async (req, res) => {
+    if (!isNonEmptyString(req.params.id)) return res.status(400).json({ error: "invalid id" });
+    const parsed = parseSubscriptionPayload(req.body, true);
+    if (parsed.error) return res.status(400).json({ error: parsed.error });
+
+    const updated = await db.subscription.update({ where: { id: req.params.id }, data: parsed.value as any });
+    return res.json(updated);
+  });
+
+  app.delete("/api/subscriptions/:id", async (req, res) => {
+    if (!isNonEmptyString(req.params.id)) return res.status(400).json({ error: "invalid id" });
+    await db.subscription.delete({ where: { id: req.params.id } });
+    return res.status(204).send();
+  });
+
+  app.post("/api/preferences", async (req, res) => {
+    const parsed = parsePreferencePayload(req.body, false);
+    if (parsed.error) return res.status(400).json({ error: parsed.error });
+
+    const created = await db.userPreference.create({ data: parsed.value as any });
+    return res.status(201).json(created);
+  });
+
+  app.get("/api/preferences/:subscriptionId", async (req, res) => {
+    if (!isNonEmptyString(req.params.subscriptionId)) return res.status(400).json({ error: "invalid subscriptionId" });
+    const row = await db.userPreference.findUnique({ where: { subscriptionId: req.params.subscriptionId } });
+    if (!row) return res.status(404).json({ error: "not found" });
+    return res.json(row);
+  });
+
+  app.patch("/api/preferences/:subscriptionId", async (req, res) => {
+    if (!isNonEmptyString(req.params.subscriptionId)) return res.status(400).json({ error: "invalid subscriptionId" });
+    const parsed = parsePreferencePayload(req.body, true);
+    if (parsed.error) return res.status(400).json({ error: parsed.error });
+
+    const updated = await db.userPreference.update({ where: { subscriptionId: req.params.subscriptionId }, data: parsed.value as any });
+    return res.json(updated);
+  });
+
+  app.delete("/api/preferences/:subscriptionId", async (req, res) => {
+    if (!isNonEmptyString(req.params.subscriptionId)) return res.status(400).json({ error: "invalid subscriptionId" });
+    await db.userPreference.delete({ where: { subscriptionId: req.params.subscriptionId } });
+    return res.status(204).send();
+  });
+
+  return app;
+}

--- a/server/lib/__tests__/api-contract.test.ts
+++ b/server/lib/__tests__/api-contract.test.ts
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { type IntelSeverity } from "../severity";
+import { createApp } from "../../app";
+
+type FeedSource = { id: string; slug: string; name: string };
+type Subscription = {
+  id: string;
+  feedSourceId: string;
+  subscriberKey: string;
+  channel: string;
+  endpoint: string;
+  isActive: boolean;
+  feedSource: FeedSource;
+};
+type Preference = {
+  id: string;
+  subscriptionId: string;
+  timezone: string;
+  digestHourUtc: number;
+  minimumSeverity: IntelSeverity;
+  includeRecommendations: boolean;
+};
+
+function createFakeDb() {
+  const feeds: FeedSource[] = [{ id: "feed-1", slug: "vendor-advisories", name: "Vendor" }];
+  const subscriptions: Subscription[] = [];
+  const preferences: Preference[] = [];
+  const intelItems = [
+    {
+      id: "intel-1",
+      title: "Critical bug",
+      severity: "CRITICAL" as IntelSeverity,
+      publishedAt: new Date("2026-01-01"),
+      feedSource: feeds[0],
+      vulnerabilities: [{ exploited: true, patched: false, vendor: "Ivanti", product: "Connect Secure" }],
+    },
+  ];
+
+  return {
+    subscription: {
+      findMany: async ({ where }: any) => {
+        const rows = subscriptions.filter((s) => {
+          if (where?.subscriberKey && s.subscriberKey !== where.subscriberKey) return false;
+          if (where?.isActive !== undefined && s.isActive !== where.isActive) return false;
+          return true;
+        });
+        return rows.map((row) => ({
+          ...row,
+          userPreference: preferences.find((p) => p.subscriptionId === row.id) ?? null,
+          feedSource: row.feedSource,
+        }));
+      },
+      create: async ({ data }: any) => {
+        const next: Subscription = {
+          id: `sub-${subscriptions.length + 1}`,
+          ...data,
+          isActive: data.isActive ?? true,
+          feedSource: feeds.find((f) => f.id === data.feedSourceId)!,
+        };
+        subscriptions.push(next);
+        return next;
+      },
+      update: async ({ where, data }: any) => {
+        const row = subscriptions.find((s) => s.id === where.id)!;
+        Object.assign(row, data);
+        return row;
+      },
+      delete: async ({ where }: any) => {
+        const idx = subscriptions.findIndex((s) => s.id === where.id);
+        subscriptions.splice(idx, 1);
+      },
+    },
+    userPreference: {
+      create: async ({ data }: any) => {
+        const next: Preference = { id: `pref-${preferences.length + 1}`, ...data };
+        preferences.push(next);
+        return next;
+      },
+      findUnique: async ({ where }: any) => preferences.find((p) => p.subscriptionId === where.subscriptionId) ?? null,
+      update: async ({ where, data }: any) => {
+        const row = preferences.find((p) => p.subscriptionId === where.subscriptionId)!;
+        Object.assign(row, data);
+        return row;
+      },
+      delete: async ({ where }: any) => {
+        const idx = preferences.findIndex((p) => p.subscriptionId === where.subscriptionId);
+        preferences.splice(idx, 1);
+      },
+    },
+    intelItem: {
+      findMany: async () => intelItems,
+    },
+  };
+}
+
+async function withServer(fn: (baseUrl: string) => Promise<void>) {
+  const app = createApp(createFakeDb() as any);
+  const server = createServer(app);
+
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("unexpected address");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await fn(baseUrl);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  }
+}
+
+test("subscription + preferences CRUD and personalized intel contract", async () => {
+  await withServer(async (baseUrl) => {
+    const badSubResp = await fetch(`${baseUrl}/api/subscriptions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ feedSourceId: "", subscriberKey: "", channel: "", endpoint: "" }),
+    });
+    assert.equal(badSubResp.status, 400);
+
+    const subResp = await fetch(`${baseUrl}/api/subscriptions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ feedSourceId: "feed-1", subscriberKey: "alice@example.com", channel: "email", endpoint: "alice@example.com" }),
+    });
+    assert.equal(subResp.status, 201);
+    const subscription = await subResp.json();
+
+    const prefResp = await fetch(`${baseUrl}/api/preferences`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        subscriptionId: subscription.id,
+        timezone: "UTC",
+        digestHourUtc: 8,
+        minimumSeverity: "HIGH",
+        includeRecommendations: true,
+      }),
+    });
+    assert.equal(prefResp.status, 201);
+
+    const intelResp = await fetch(`${baseUrl}/api/users/alice@example.com/personalized-intel`);
+    assert.equal(intelResp.status, 200);
+    const intelPayload = await intelResp.json();
+    assert.equal(intelPayload.context.minimumSeverity, "HIGH");
+    assert.equal(intelPayload.items.length, 1);
+
+    const patchPrefResp = await fetch(`${baseUrl}/api/preferences/${subscription.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ digestHourUtc: 23, includeRecommendations: false }),
+    });
+    assert.equal(patchPrefResp.status, 200);
+
+    const deletePrefResp = await fetch(`${baseUrl}/api/preferences/${subscription.id}`, { method: "DELETE" });
+    assert.equal(deletePrefResp.status, 204);
+
+    const deleteSubResp = await fetch(`${baseUrl}/api/subscriptions/${subscription.id}`, { method: "DELETE" });
+    assert.equal(deleteSubResp.status, 204);
+  });
+});

--- a/server/lib/__tests__/personalization.test.ts
+++ b/server/lib/__tests__/personalization.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { type IntelSeverity } from "../severity";
+import { scoreIntelForUser } from "../personalization";
+
+test("scores differ across user profiles", () => {
+  const intel = {
+    id: "intel-1",
+    title: "Critical Ivanti bug",
+    severity: "CRITICAL" as const,
+    feedSourceSlug: "vendor-advisories",
+    vulnerabilities: [{ exploited: true, patched: false, vendor: "Ivanti", product: "Connect Secure" }],
+  };
+
+  const secopsScore = scoreIntelForUser(intel, {
+    subscribedSourceSlugs: ["vendor-advisories"],
+    minimumSeverity: "HIGH",
+    includeRecommendations: true,
+  });
+
+  const lowPriorityScore = scoreIntelForUser(intel, {
+    subscribedSourceSlugs: [],
+    minimumSeverity: "CRITICAL",
+    includeRecommendations: false,
+  });
+
+  assert.ok(secopsScore > lowPriorityScore);
+});

--- a/server/lib/personalization.ts
+++ b/server/lib/personalization.ts
@@ -1,0 +1,60 @@
+import { type IntelSeverity } from "./severity";
+
+export type UserContext = {
+  subscribedSourceSlugs: string[];
+  minimumSeverity: IntelSeverity;
+  includeRecommendations: boolean;
+};
+
+export type ScorableIntel = {
+  id: string;
+  title: string;
+  severity: IntelSeverity;
+  feedSourceSlug: string;
+  vulnerabilities: Array<{
+    exploited: boolean;
+    patched: boolean;
+    vendor: string | null;
+    product: string | null;
+  }>;
+};
+
+const severityWeights: Record<IntelSeverity, number> = {
+  LOW: 10,
+  MEDIUM: 30,
+  HIGH: 60,
+  CRITICAL: 85,
+};
+
+const severityRank: Record<IntelSeverity, number> = {
+  LOW: 0,
+  MEDIUM: 1,
+  HIGH: 2,
+  CRITICAL: 3,
+};
+
+export function scoreIntelForUser(intel: ScorableIntel, context: UserContext): number {
+  let score = severityWeights[intel.severity];
+
+  if (context.subscribedSourceSlugs.includes(intel.feedSourceSlug)) {
+    score += 20;
+  }
+
+  if (intel.vulnerabilities.some((v) => v.exploited)) {
+    score += 15;
+  }
+
+  if (intel.vulnerabilities.some((v) => v.patched)) {
+    score -= 8;
+  }
+
+  if (!context.includeRecommendations) {
+    score -= 3;
+  }
+
+  if (severityRank[intel.severity] < severityRank[context.minimumSeverity]) {
+    score -= 30;
+  }
+
+  return Math.max(0, Math.min(100, score));
+}

--- a/server/lib/severity.ts
+++ b/server/lib/severity.ts
@@ -1,0 +1,2 @@
+export const INTEL_SEVERITIES = ["LOW", "MEDIUM", "HIGH", "CRITICAL"] as const;
+export type IntelSeverity = (typeof INTEL_SEVERITIES)[number];


### PR DESCRIPTION
### Motivation
- Replace static/hardcoded user context with real user preferences/subscriptions stored in the DB so personalization is data-driven. 
- Apply user context to ranking so intel is scored according to subscription source affinity and user preference thresholds. 
- Expose CRUD APIs to manage `Subscription` and `UserPreference` records and validate all payloads to prevent invalid state.

### Description
- Added a reusable Express app factory `createApp` and wired the app into the server bootstrap (`server/app.ts`, `server.ts`).
- Implemented personalization scoring and types in `server/lib/personalization.ts` and a local severity type in `server/lib/severity.ts` and replaced stubbed context with `loadUserContext` that loads active subscriptions and merged preferences from the DB.
- Added subscription & preference CRUD endpoints with request/param validation: `GET /api/users/:subscriberKey/context`, `GET /api/users/:subscriberKey/personalized-intel`, `GET /api/subscriptions`, `POST/PATCH/DELETE /api/subscriptions/:id`, and `POST/GET/PATCH/DELETE /api/preferences/:subscriptionId` (see `server/app.ts`).
- Added API contract and scoring tests: `server/lib/__tests__/api-contract.test.ts` and `server/lib/__tests__/personalization.test.ts`, and preserved existing connector and ingestion tests.

### Testing
- Ran lint with `npm run lint` (TypeScript `--noEmit`) and it completed successfully.
- Ran the test suite with `npm test` which executed `server/lib/__tests__/*.test.ts` including `api-contract.test.ts`, `personalization.test.ts`, `connectors.test.ts`, and `ingest-smoke.test.ts`, and all tests passed.
- The personalized scoring behavior is covered by `personalization.test.ts` which asserts score differences across user profiles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eb0a65988323b6b37039bedc6138)