### PR TITLE
Harden SecurePulse APIs with validation, rate limiting, audit logs, and ops metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "node server.ts",
     "preview": "vite preview",
     "clean": "rm -rf dist",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "node --test --import tsx test/api.security.test.ts"
   },
   "dependencies": {
     "@google/genai": "^1.29.0",

--- a/server.ts
+++ b/server.ts
@@ -1,21 +1,14 @@
 import express from "express";
 import { createServer as createViteServer } from "vite";
 import dotenv from "dotenv";
+import { createApp } from "./src/backend/app";
 
 dotenv.config();
 
-async function startServer() {
-  const app = express();
+export async function startServer() {
+  const app = createApp();
   const PORT = 3000;
 
-  app.use(express.json());
-
-  // API routes go here
-  app.get("/api/health", (req, res) => {
-    res.json({ status: "ok", app: "SecurePulse MVP" });
-  });
-
-  // Vite middleware for development
   if (process.env.NODE_ENV !== "production") {
     const vite = await createViteServer({
       server: { middlewareMode: true },
@@ -23,7 +16,6 @@ async function startServer() {
     });
     app.use(vite.middlewares);
   } else {
-    // In production, serve the built static files
     app.use(express.static("dist"));
   }
 

--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -1,0 +1,266 @@
+import express, { type NextFunction, type Request, type Response } from "express";
+import db from "../lib/db";
+import crypto from "crypto";
+
+type ErrorEnvelope = {
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+};
+
+class ApiError extends Error {
+  status: number;
+  code: string;
+  details?: Record<string, unknown>;
+
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+type Validator = (body: unknown) => string[];
+
+const validateBody = (validator: Validator) => (req: Request, _res: Response, next: NextFunction) => {
+  const errors = validator(req.body);
+  if (errors.length > 0) {
+    return next(new ApiError(400, "VALIDATION_ERROR", "Request payload is invalid", { errors }));
+  }
+  next();
+};
+
+const rateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+const rateLimit = (bucketName: string) => (req: Request, _res: Response, next: NextFunction) => {
+  const rateWindowMs = Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000);
+  const rateMaxRequests = Number(process.env.RATE_LIMIT_MAX_REQUESTS || 5);
+  const ip = req.ip || req.socket.remoteAddress || "unknown";
+  const key = `${bucketName}:${ip}`;
+  const now = Date.now();
+  const bucket = rateBuckets.get(key);
+
+  if (!bucket || now >= bucket.resetAt) {
+    rateBuckets.set(key, { count: 1, resetAt: now + rateWindowMs });
+    return next();
+  }
+
+  if (bucket.count >= rateMaxRequests) {
+    return next(new ApiError(429, "RATE_LIMITED", "Too many requests, please retry later"));
+  }
+
+  bucket.count += 1;
+  next();
+};
+
+const validateIntelItem: Validator = (body) => {
+  const errors: string[] = [];
+  if (!body || typeof body !== "object") {
+    return ["Body must be a JSON object"];
+  }
+
+  const payload = body as Record<string, unknown>;
+  const requiredStringFields = ["source", "externalId", "title", "content", "publishedAt"];
+  for (const field of requiredStringFields) {
+    if (typeof payload[field] !== "string" || (payload[field] as string).trim() === "") {
+      errors.push(`${field} is required and must be a non-empty string`);
+    }
+  }
+
+  if (payload.url !== undefined && typeof payload.url !== "string") {
+    errors.push("url must be a string when provided");
+  }
+
+  return errors;
+};
+
+const validateIntelUpdate: Validator = (body) => {
+  const errors: string[] = [];
+  if (!body || typeof body !== "object") {
+    return ["Body must be a JSON object"];
+  }
+
+  const payload = body as Record<string, unknown>;
+  const allowed = ["source", "externalId", "title", "content", "publishedAt", "url"];
+  const keys = Object.keys(payload);
+  if (keys.length === 0) {
+    return ["At least one field is required"];
+  }
+
+  for (const key of keys) {
+    if (!allowed.includes(key)) {
+      errors.push(`${key} is not a supported field`);
+      continue;
+    }
+
+    if (payload[key] !== undefined && typeof payload[key] !== "string") {
+      errors.push(`${key} must be a string when provided`);
+    }
+  }
+
+  return errors;
+};
+
+const insertIntel = db.prepare(`
+  INSERT INTO intel_items (id, source, external_id, title, content, url, published_at)
+  VALUES (@id, @source, @externalId, @title, @content, @url, @publishedAt)
+`);
+
+const updateIntel = db.prepare(`
+  UPDATE intel_items SET
+    source = COALESCE(@source, source),
+    external_id = COALESCE(@externalId, external_id),
+    title = COALESCE(@title, title),
+    content = COALESCE(@content, content),
+    url = COALESCE(@url, url),
+    published_at = COALESCE(@publishedAt, published_at)
+  WHERE id = @id
+`);
+
+const deleteIntel = db.prepare(`DELETE FROM intel_items WHERE id = ?`);
+const listIntel = db.prepare(`SELECT * FROM intel_items ORDER BY created_at DESC LIMIT 50`);
+
+const writeAudit = db.prepare(`
+  INSERT INTO audit_logs (id, operation, entity, entity_id, actor, metadata)
+  VALUES (@id, @operation, @entity, @entityId, @actor, @metadata)
+`);
+
+function auditLog(req: Request, operation: "create" | "update" | "delete", entityId: string, metadata: Record<string, unknown>) {
+  const actor = req.header("x-actor-id") || "system";
+  const entry = {
+    id: crypto.randomUUID(),
+    operation,
+    entity: "intel_item",
+    entityId,
+    actor,
+    metadata: JSON.stringify(metadata),
+  };
+
+  writeAudit.run(entry);
+  console.info("audit_log", { ...entry, metadata });
+}
+
+function metricsSnapshot() {
+  const intelCount = db.prepare("SELECT COUNT(*) as count FROM intel_items").get() as { count: number };
+  const auditCount = db.prepare("SELECT COUNT(*) as count FROM audit_logs").get() as { count: number };
+
+  return {
+    app: "SecurePulse",
+    uptimeSeconds: Math.floor(process.uptime()),
+    intelItemCount: intelCount.count,
+    auditLogCount: auditCount.count,
+  };
+}
+
+function requireOpsToken(req: Request, _res: Response, next: NextFunction) {
+  const expectedToken = process.env.OPS_TOKEN;
+  if (!expectedToken) {
+    return next(new ApiError(503, "OPS_DISABLED", "Operations endpoint is not configured"));
+  }
+
+  if (req.header("x-ops-token") !== expectedToken) {
+    return next(new ApiError(401, "UNAUTHORIZED", "Invalid operations token"));
+  }
+
+  next();
+}
+
+function sendError(err: unknown, _req: Request, res: Response<ErrorEnvelope>, _next: NextFunction) {
+  if (err instanceof ApiError) {
+    return res.status(err.status).json({
+      error: {
+        code: err.code,
+        message: err.message,
+        details: err.details,
+      },
+    });
+  }
+
+  console.error(err);
+  return res.status(500).json({
+    error: {
+      code: "INTERNAL_ERROR",
+      message: "An unexpected error occurred",
+    },
+  });
+}
+
+export function createApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.get("/api/health", (_req, res) => {
+    res.json({ data: { status: "ok", app: "SecurePulse MVP" } });
+  });
+
+  app.get("/api/intel", (_req, res) => {
+    res.json({ data: listIntel.all() });
+  });
+
+  app.post("/api/intel", rateLimit("intel-write"), validateBody(validateIntelItem), (req, res, next) => {
+    try {
+      const payload = req.body as Record<string, string>;
+      const id = crypto.randomUUID();
+      insertIntel.run({
+        id,
+        source: payload.source,
+        externalId: payload.externalId,
+        title: payload.title,
+        content: payload.content,
+        url: payload.url || null,
+        publishedAt: payload.publishedAt,
+      });
+
+      auditLog(req, "create", id, { source: payload.source, externalId: payload.externalId });
+      res.status(201).json({ data: { id } });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.put("/api/intel/:id", rateLimit("intel-write"), validateBody(validateIntelUpdate), (req, res, next) => {
+    try {
+      const id = req.params.id;
+      const payload = req.body as Record<string, string>;
+      const result = updateIntel.run({ id, ...payload });
+      if (result.changes === 0) {
+        throw new ApiError(404, "NOT_FOUND", "Intel item not found");
+      }
+
+      auditLog(req, "update", id, { fields: Object.keys(payload) });
+      res.json({ data: { id, updated: true } });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.delete("/api/intel/:id", rateLimit("intel-write"), (req, res, next) => {
+    try {
+      const id = req.params.id;
+      const result = deleteIntel.run(id);
+      if (result.changes === 0) {
+        throw new ApiError(404, "NOT_FOUND", "Intel item not found");
+      }
+
+      auditLog(req, "delete", id, {});
+      res.json({ data: { id, deleted: true } });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/api/ops/metrics", requireOpsToken, (_req, res) => {
+    res.json({ data: metricsSnapshot() });
+  });
+
+  app.use(sendError);
+
+  return app;
+}
+
+export function resetRateLimits() {
+  rateBuckets.clear();
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -41,6 +41,17 @@ db.exec(`
     confidence TEXT NOT NULL,
     FOREIGN KEY(brief_id) REFERENCES daily_briefs(id)
   );
+
+  CREATE TABLE IF NOT EXISTS audit_logs (
+    id TEXT PRIMARY KEY,
+    operation TEXT NOT NULL,
+    entity TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    metadata TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+
 `);
 
 export default db;

--- a/test/api.security.test.ts
+++ b/test/api.security.test.ts
@@ -1,0 +1,82 @@
+import test, { afterEach, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import db from "../src/lib/db";
+import { createApp, resetRateLimits } from "../src/backend/app";
+import type { AddressInfo } from "node:net";
+
+let baseUrl = "";
+let closeServer: (() => Promise<void>) | null = null;
+
+beforeEach(async () => {
+  process.env.RATE_LIMIT_WINDOW_MS = "60000";
+  process.env.RATE_LIMIT_MAX_REQUESTS = "2";
+  process.env.OPS_TOKEN = "ops-secret";
+
+  db.exec("DELETE FROM audit_logs;");
+  db.exec("DELETE FROM intel_items;");
+  resetRateLimits();
+
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+  closeServer = async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  };
+});
+
+afterEach(async () => {
+  if (closeServer) {
+    await closeServer();
+  }
+});
+
+test("invalid payload returns standardized validation envelope", async () => {
+  const response = await fetch(`${baseUrl}/api/intel`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ source: "rss" }),
+  });
+
+  assert.equal(response.status, 400);
+  const body = (await response.json()) as { error: { code: string; details: { errors: string[] } } };
+  assert.equal(body.error.code, "VALIDATION_ERROR");
+  assert.ok(body.error.details.errors.length > 0);
+});
+
+test("rate limit triggers on key write endpoints", async () => {
+  const payload = {
+    source: "rss",
+    externalId: "ext-1",
+    title: "Alert",
+    content: "content",
+    publishedAt: new Date().toISOString(),
+  };
+
+  const first = await fetch(`${baseUrl}/api/intel`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  assert.equal(first.status, 201);
+
+  const second = await fetch(`${baseUrl}/api/intel`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...payload, externalId: "ext-2" }),
+  });
+  assert.equal(second.status, 201);
+
+  const third = await fetch(`${baseUrl}/api/intel`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...payload, externalId: "ext-3" }),
+  });
+
+  assert.equal(third.status, 429);
+  const body = (await third.json()) as { error: { code: string } };
+  assert.equal(body.error.code, "RATE_LIMITED");
+});


### PR DESCRIPTION
### Motivation
- Centralize and standardize request validation and error handling to reduce duplicate checks and provide consistent API responses.
- Protect important write paths from abuse with a simple rate-limiter and add audit trails for create/update/delete operations for improved observability.
- Expose an operations metrics endpoint that is gated for admins/operators to support safe operational introspection.

### Description
- Added a backend app factory `createApp` in `src/backend/app.ts` that implements an `ApiError` envelope and a centralized `validateBody` middleware for request validation.
- Implemented an in-memory rate limiting middleware `rateLimit` and `resetRateLimits()` and applied it to key write endpoints for intel (`POST/PUT/DELETE /api/intel`).
- Added audit logging for create/update/delete intel operations persisted to a new `audit_logs` table and emitted as structured logs via `auditLog`.
- Added a protected operations endpoint `/api/ops/metrics` gated by `x-ops-token` (`OPS_TOKEN`), refactored `server.ts` to use `createApp`, and extended the DB schema in `src/lib/db.ts` to include `audit_logs`.
- Added automated tests `test/api.security.test.ts` covering invalid payload validation envelope shape and write-endpoint rate limiting, and a `test` npm script to run them.

### Testing
- Ran `npm test` which executed the API tests and both subtests passed (validation envelope and rate-limiting checks passed).
- Ran `npm run lint` (`tsc --noEmit`) and the TypeScript lint/type-check passed without errors.
- Local test harness used `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX_REQUESTS`, and `OPS_TOKEN` environment variables to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fe048b3883239b34f3365a79ad56)