### PR TITLE
Move GEMINI_API_KEY validation to server startup

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -7,6 +7,14 @@ import {generateBriefCard} from './src/lib/ai.ts';
 
 dotenv.config();
 
+if (!process.env.GEMINI_API_KEY) {
+  throw new Error(
+    'Missing required environment variable: GEMINI_API_KEY\n' +
+    'Please set GEMINI_API_KEY in your .env file or in the process environment before starting the server.\n' +
+    'Example: GEMINI_API_KEY=your-api-key-here'
+  );
+}
+
 type DailyBriefRow = {id: string; date: string; created_at: string};
 type BriefCardRow = {
   id: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,11 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-import {defineConfig, loadEnv} from 'vite';
+import {defineConfig} from 'vite';
 
-export default defineConfig(({mode}) => {
-  const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
   return {
     plugins: [react(), tailwindcss()],
-    define: {
-      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
Moved GEMINI_API_KEY environment variable validation from the Vite build configuration to server startup, ensuring the API key is validated at runtime rather than build time.

## Key Changes
- Added explicit validation in `server.ts` that throws a descriptive error if `GEMINI_API_KEY` is missing when the server starts
- Removed `GEMINI_API_KEY` from Vite's `define` configuration in `vite.config.ts`
- Removed unused `loadEnv` import from Vite config
- Simplified Vite config by removing the `mode` parameter and `define` object

## Implementation Details
The validation now occurs at server startup with a clear error message that guides users to set the environment variable in their `.env` file or process environment. This approach:
- Provides better error messaging at runtime when the variable is actually needed
- Removes the need to expose the API key through the Vite build process
- Ensures the validation happens in the backend where the API key is actually used

https://claude.ai/code/session_01GRy1MuiZFZX6ioumt4BPEr